### PR TITLE
Add support for accept_ms_testers_without_closed_task

### DIFF
--- a/action.js
+++ b/action.js
@@ -329,7 +329,7 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
   const asanaSettings = mobsuccessyml.asana || {};
   if (asanaSettings.accept_ms_testers_without_closed_task) {
     console.log(
-      "accept_ms_testers_without_closed_task is set to true, merging"
+      "accept_ms_testers_without_closed_task is set to true, ok to merge"
     );
     return true;
   }

--- a/lib/mobsuccessyml.js
+++ b/lib/mobsuccessyml.js
@@ -1,0 +1,19 @@
+const yaml = require("js-yaml");
+const { octokit } = require("./actions/octokit");
+
+exports.getMobsuccessYMLFromRepo = async function getMobsuccessYMLFromRepo({
+  owner,
+  repo,
+}) {
+  try {
+    const { data } = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      path: ".mobsuccess.yml",
+    });
+    const content = Buffer.from(data.content, "base64").toString("utf8");
+    return yaml.load(content);
+  } catch (e) {
+    return {};
+  }
+};


### PR DESCRIPTION
### What does it do? Why?

👉🏻 On a few repositories, such as @mobsuccess-devops/mobsuccess , it is necessary to be able to merge PRs without the corresponding Asana task being closed.

This PR adds compatibility with this : 

The repo must have a `mobsuccess.yml` file at root with the following content:
```yml
asana:
  accept_ms_testers_without_closed_task: true
```
And the PR must be assigned to @ms-testers 

### Good To Know

👉🏻 https://mobsuccess.slack.com/archives/C031L5J9F96/p1675262014282969
