### PR TITLE
Fix bypass accept_ms_testers_without_closed_task

### DIFF
--- a/action.js
+++ b/action.js
@@ -318,10 +318,6 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
   const { assignees } = pullRequest;
   const assigneeLogins = assignees.map(({ login }) => login);
   if (!assigneeLogins.some((login) => login === "ms-testers")) {
-    console.log(
-      "ms-testers is not assigned in " +
-        JSON.stringify({ assignees, assigneeLogins })
-    );
     return false;
   }
 
@@ -331,12 +327,6 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
     repo: repository.name,
     branch: pullRequest.head.ref,
   });
-  console.log(
-    "using mobsuccessyml " +
-      JSON.stringify(mobsuccessyml) +
-      " on branch " +
-      pullRequest.head.ref
-  );
   const asanaSettings = mobsuccessyml.asana || {};
   if (asanaSettings.accept_ms_testers_without_closed_task) {
     console.log(
@@ -364,13 +354,7 @@ exports.action = async function action() {
   //console.log("pull", pullRequest);
   console.log("asanaPRStatus", asanaPRStatus);
 
-  console.info(
-    `Calling action ${action} with payload ${JSON.stringify(
-      { repository, pullRequest },
-      undefined,
-      4
-    )}`
-  );
+  console.info(`Calling action`);
   switch (action) {
     case "debug":
       console.log(

--- a/action.js
+++ b/action.js
@@ -325,6 +325,7 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
   const mobsuccessyml = await getMobsuccessYMLFromRepo({
     owner: repository.owner.login,
     repo: repository.name,
+    branch: pullRequest.head.ref,
   });
   const asanaSettings = mobsuccessyml.asana || {};
   if (asanaSettings.accept_ms_testers_without_closed_task) {

--- a/action.js
+++ b/action.js
@@ -354,7 +354,7 @@ exports.action = async function action() {
   //console.log("pull", pullRequest);
   console.log("asanaPRStatus", asanaPRStatus);
 
-  console.info(`Calling action`);
+  console.info(`Calling action ${action}`);
   switch (action) {
     case "debug":
       console.log(

--- a/action.js
+++ b/action.js
@@ -318,6 +318,10 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
   const { assignees } = pullRequest;
   const assigneeLogins = assignees.map(({ login }) => login);
   if (!assigneeLogins.some((login) => login === "ms-testers")) {
+    console.log(
+      "ms-testers is not assigned in " +
+        JSON.stringify({ assignees, assigneeLogins })
+    );
     return false;
   }
 
@@ -327,6 +331,12 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
     repo: repository.name,
     branch: pullRequest.head.ref,
   });
+  console.log(
+    "using mobsuccessyml " +
+      JSON.stringify(mobsuccessyml) +
+      " on branch " +
+      pullRequest.head.ref
+  );
   const asanaSettings = mobsuccessyml.asana || {};
   if (asanaSettings.accept_ms_testers_without_closed_task) {
     console.log(

--- a/action.js
+++ b/action.js
@@ -353,7 +353,13 @@ exports.action = async function action() {
   //console.log("pull", pullRequest);
   console.log("asanaPRStatus", asanaPRStatus);
 
-  console.info(`Calling action ${action}`);
+  console.info(
+    `Calling action ${action} with payload ${JSON.stringify(
+      { repository, pullRequest },
+      undefined,
+      4
+    )}`
+  );
   switch (action) {
     case "debug":
       console.log(

--- a/action.js
+++ b/action.js
@@ -325,7 +325,7 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
   const mobsuccessyml = await getMobsuccessYMLFromRepo({
     owner: repository.owner.login,
     repo: repository.name,
-    branch: pullRequest.head.ref,
+    branch: pullRequest.head ? pullRequest.head.ref : "master",
   });
   const asanaSettings = mobsuccessyml.asana || {};
   if (asanaSettings.accept_ms_testers_without_closed_task) {

--- a/lib/mobsuccessyml.js
+++ b/lib/mobsuccessyml.js
@@ -9,7 +9,7 @@ exports.getMobsuccessYMLFromRepo = async function getMobsuccessYMLFromRepo({
   branch,
 }) {
   try {
-    const { data } = await octokit.rest.repos.getContent({
+    const { data } = await octokit.repos.getContent({
       owner,
       repo,
       path: ".mobsuccess.yml",

--- a/lib/mobsuccessyml.js
+++ b/lib/mobsuccessyml.js
@@ -4,12 +4,14 @@ const { octokit } = require("./actions/octokit");
 exports.getMobsuccessYMLFromRepo = async function getMobsuccessYMLFromRepo({
   owner,
   repo,
+  branch,
 }) {
   try {
     const { data } = await octokit.rest.repos.getContent({
       owner,
       repo,
       path: ".mobsuccess.yml",
+      ref: branch ?? "master",
     });
     const content = Buffer.from(data.content, "base64").toString("utf8");
     return yaml.load(content);

--- a/lib/mobsuccessyml.js
+++ b/lib/mobsuccessyml.js
@@ -1,5 +1,5 @@
 const yaml = require("js-yaml");
-const getOctokit = require("./lib/actions/octokit");
+const getOctokit = require("./actions/octokit");
 
 const octokit = getOctokit();
 

--- a/lib/mobsuccessyml.js
+++ b/lib/mobsuccessyml.js
@@ -16,6 +16,7 @@ exports.getMobsuccessYMLFromRepo = async function getMobsuccessYMLFromRepo({
     const content = Buffer.from(data.content, "base64").toString("utf8");
     return yaml.load(content);
   } catch (e) {
+    console.log("Error getting .mobsuccess.yml from repo", e);
     return {};
   }
 };

--- a/lib/mobsuccessyml.js
+++ b/lib/mobsuccessyml.js
@@ -1,5 +1,7 @@
 const yaml = require("js-yaml");
-const { octokit } = require("./actions/octokit");
+const getOctokit = require("./lib/actions/octokit");
+
+const octokit = getOctokit();
 
 exports.getMobsuccessYMLFromRepo = async function getMobsuccessYMLFromRepo({
   owner,

--- a/lib/mobsuccessyml.js
+++ b/lib/mobsuccessyml.js
@@ -11,7 +11,7 @@ exports.getMobsuccessYMLFromRepo = async function getMobsuccessYMLFromRepo({
       owner,
       repo,
       path: ".mobsuccess.yml",
-      ref: branch ?? "master",
+      ref: branch || "master",
     });
     const content = Buffer.from(data.content, "base64").toString("utf8");
     return yaml.load(content);


### PR DESCRIPTION
### What does it do? Why?

This is a fix after #41 

👉🏻 On a few repositories, such as https://github.com/orgs/mobsuccess-devops/teams/mobsuccess , it is necessary to be able to merge PRs without the corresponding Asana task being closed.

This PR adds compatibility with this :

The repo must have a mobsuccess.yml file at root with the following content:

asana:
  accept_ms_testers_without_closed_task: true
And the PR must be assigned to @ms-testers

Good To Know
👉🏻 https://mobsuccess.slack.com/archives/C031L5J9F96/p1675262014282969
