### PR TITLE
Add support for merge group runs

### DIFF
--- a/action.js
+++ b/action.js
@@ -338,6 +338,14 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
 }
 
 exports.action = async function action() {
+  // check if we run on a merge_group
+  const { merge_group } = github.context.payload;
+  if (merge_group) {
+    console.log("merge_group", merge_group);
+  } else {
+    console.log("no merge_group");
+  }
+
   const {
     repository,
     pullRequest,
@@ -346,6 +354,7 @@ exports.action = async function action() {
     amplifyUri,
     storybookAmplifyUri,
   } = exports.getActionParameters();
+
   const taskId = exports.findAsanaTaskId({ triggerPhrase, pullRequest });
 
   const asanaPRStatus = await exports.getAsanaPRStatus({

--- a/action.js
+++ b/action.js
@@ -125,6 +125,7 @@ exports.getActionParameters = function getActionParameters() {
   const triggerPhrase = core.getInput("trigger-phrase") || "";
   const amplifyUri = core.getInput("amplify-uri") || "";
   const storybookAmplifyUri = core.getInput("storybook-amplify-uri") || "";
+  const mergeGroup = core.getInput("merge-group");
   return {
     repository,
     pullRequest,
@@ -132,6 +133,7 @@ exports.getActionParameters = function getActionParameters() {
     triggerPhrase,
     amplifyUri,
     storybookAmplifyUri,
+    mergeGroup,
   };
 };
 
@@ -339,14 +341,8 @@ async function checkIfCanMergeWithoutAsanaTask({ repository, pullRequest }) {
 
 exports.action = async function action() {
   // check if we run on a merge_group
-  const { merge_group } = github.context.payload;
-  if (merge_group) {
-    console.log("merge_group", merge_group);
-  } else {
-    console.log("no merge_group");
-  }
-
   const {
+    mergeGroup,
     repository,
     pullRequest,
     action,
@@ -354,6 +350,11 @@ exports.action = async function action() {
     amplifyUri,
     storybookAmplifyUri,
   } = exports.getActionParameters();
+
+  if (mergeGroup) {
+    console.log("Running on a merge group - skipping Asana integration");
+    return;
+  }
 
   const taskId = exports.findAsanaTaskId({ triggerPhrase, pullRequest });
 

--- a/action.js
+++ b/action.js
@@ -121,11 +121,11 @@ exports.findAsanaTaskId = function findAsanaTaskId({
 exports.getActionParameters = function getActionParameters() {
   const repository = github.context.payload.repository;
   const pullRequest = github.context.payload.pull_request;
+  const mergeGroup = github.context.payload.merge_group;
   const action = core.getInput("action", { required: true });
   const triggerPhrase = core.getInput("trigger-phrase") || "";
   const amplifyUri = core.getInput("amplify-uri") || "";
   const storybookAmplifyUri = core.getInput("storybook-amplify-uri") || "";
-  const mergeGroup = core.getInput("merge-group");
   return {
     repository,
     pullRequest,

--- a/sample/workflows/asana.yml
+++ b/sample/workflows/asana.yml
@@ -1,6 +1,10 @@
 name: Asana
 
 on:
+  merge_group:
+    types:
+      - checks_requested
+
   pull_request:
     types:
       - assigned


### PR DESCRIPTION
### What does it do? Why?

- This action expects a pull request passed in the GH context, but when ran in merge queues, we don't have those.
- when ran in merge queues, it means the PR has already been validated by every check: therefore we know that the Asana task was successful
- => we can bypass the Asana task when running in merge queue

### Good To Know

👉🏻 https://mobsuccess.slack.com/archives/C031L5J9F96/p1677249660944709