### PR TITLE
Add concurrency to cancel concurrent runs

### DIFF
--- a/sample/workflows/asana.yml
+++ b/sample/workflows/asana.yml
@@ -24,6 +24,10 @@ on:
       - edited
       - dismissed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Asana:
     runs-on: ubuntu-latest


### PR DESCRIPTION
What does it do? Why?

👉🏻 Add concurrency settings to cancel previously running Asana Jobs. This is because of the suspicion that Asana GHA errors occurs because of this concurrency (when a lot of jobs are launched at the same time)

Good To Know

👉🏻 This is a test to validate the solution on platform-dashboard - if validated, it will. be put in the Asana's sample workflow for a global deployment