### PR TITLE
Add support for multiple amplify URIs in monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ The MS robot will automatically create a PR on your repository.
 If your repository is linked to AWS Amplify, you can dynamically update the
 Amplify hostname link. To do so, create a secret in your repository named
 `AWS_AMPLIFY_URI` with a value such as `https://pr-%.foo.live.mobsuccess.com`.
+
+If your repository supports multiple domains, this value can be a JSON:
+
+```json
+{
+  "webapps/lcm": "https://pr-%.platform-lcm.live.mobsuccess.com",
+  "webapps/lco": "https://pr-%.platform-lco.live.mobsuccess.com"
+}
+```

--- a/action.js
+++ b/action.js
@@ -347,7 +347,6 @@ function getAwsAmplifyLiveUrls({ id, labels, amplifyUri }) {
   const result = [];
   if (amplifyUri.match(/^{/)) {
     const amplifyUris = JSON.parse(amplifyUri);
-    // amplifyUris is now an object mapping potential labels to URIs
     for (const label of labels) {
       if (amplifyUris[label]) {
         result.push(amplifyUris[label].replace("%", id));


### PR DESCRIPTION
### What does it do? Why?

So that we can track `mobsuccess-front` and maybe others
